### PR TITLE
Discrete Bayes Filter: events in example of conditional probability are put vice-versa

### DIFF
--- a/02_Discrete_Bayes.ipynb
+++ b/02_Discrete_Bayes.ipynb
@@ -1659,7 +1659,7 @@
     "\n",
     "If you are not familiar with this notation, let's review. $P(A)$ means the probability of event $A$. If $A$ is the event of a fair coin landing heads, then $P(A) = 0.5$.\n",
     "\n",
-    "$P(A|B)$ is called a *conditional probability*. That is, it represents the probability of $A$ happening *if* $B$ happened. For example, it is more likely to rain today if it also rained yesterday. We'd write that as $P(rain_{yesterday}|rain_{today})$.\n",
+    "$P(A|B)$ is called a *conditional probability*. That is, it represents the probability of $A$ happening *if* $B$ happened. For example, it is more likely to rain today if it also rained yesterday. We'd write that as $P(rain_{today}|rain_{yesterday})$.\n",
     "\n",
     "In Bayesian statistics $P(A)$ is the *prior*, and $P(A|B)$ is the *posterior*. To see why, let's rewrite the equation in terms of our problem. We will use $x_i$ for the position at *i*, and $Z$ for the measurement. Hence, we want to know $P(x_i|Z)$, that is, the probability of the dog being at $x_i$ given the measurement $Z$. \n",
     "\n",


### PR DESCRIPTION
Maybe I'm wrong, but it seems to me that events in example of conditional probability were put vice-versa.