### PR TITLE
Fix systemic_resample() float indexes bug

### DIFF
--- a/code/RobotLocalizationParticleFilter.py
+++ b/code/RobotLocalizationParticleFilter.py
@@ -165,7 +165,7 @@ def residual_resample2(w):
 def systemic_resample(w):
     N = len(w)
     Q = np.cumsum(w)
-    indexes = np.zeros(N)
+    indexes = np.zeros(N, 'int')
     t = np.linspace(0, 1-1/N, N) + random()/N
 
     i, j = 0, 0


### PR DESCRIPTION
Variable 'indexes' should be created as array of  type 'int'