### PR TITLE
Fixed JSON settings being overwritten with matplotlib version.

### DIFF
--- a/code/book_format.py
+++ b/code/book_format.py
@@ -124,7 +124,7 @@ def load_style(directory = '.', name='code/custom.css'):
 
     # matplotlib has deprecated the use of axes.color_cycle as of version
 
-    version = [int(s) for s in matplotlib.__version__.split('.')]
+    version = [int(version_no) for version_no in matplotlib.__version__.split('.')]
     if version[0] > 1 or (version[0] == 1 and version[1] >= 5):
         s["axes.prop_cycle"] = "cycler('color', ['#6d904f','#013afe', '#202020','#fc4f30','#e5ae38','#A60628','#30a2da','#008080','#7A68A6','#CF4457','#188487','#E24A33'])"
         s.pop("axes.color_cycle", None)


### PR DESCRIPTION
The ```s``` dictionary containing the JSON settings is being overwritten with the matplotlib version in line 127, resulting in:
```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-34-a550bbe40f47> in <module>()
      7 sys.path.insert(0,'./code')
      8 from book_format import load_style
----> 9 load_style()

/home/dragos/Projects/testkalmanbook/Kalman-and-Bayesian-Filters-in-Python/code/book_format.py in load_style(directory, name)
    127 
    128     if version[0] > 1 or (version[0] == 1 and version[1] >= 5):
--> 129         s["axes.prop_cycle"] = "cycler('color', ['#6d904f','#013afe', '#202020','#fc4f30','#e5ae38','#A60628','#30a2da','#008080','#7A68A6','#CF4457','#188487','#E24A33'])"
    130         s.pop("axes.color_cycle", None)
    131 

TypeError: 'unicode' object does not support item assignment
```