### PR TITLE
Unscented Kalman Filter: using "state estimate" instead of "mean estimate" in the covariance equation at the predict step

### DIFF
--- a/10-Unscented-Kalman-Filter.ipynb
+++ b/10-Unscented-Kalman-Filter.ipynb
@@ -6184,7 +6184,7 @@
     "\\mathbf{\\bar x} = \\mathbf{Fx} & \n",
     "\\mathbf{\\bar x} = \\sum w^m\\boldsymbol{\\mathcal Y}  \\\\\n",
     "\\mathbf{\\bar P} = \\mathbf{FPF}^\\mathsf T+\\mathbf Q  & \n",
-    "\\mathbf{\\bar P} = \\sum w^c({\\boldsymbol{\\mathcal Y}-\\bar{\\boldsymbol\\mu})(\\boldsymbol{\\mathcal Y} - \\bar{\\boldsymbol\\mu})^\\mathsf{T}} + \\mathbf Q \\\\\n",
+    "\\mathbf{\\bar P} = \\sum w^c({\\boldsymbol{\\mathcal Y} - \\mathbf{\\bar x})(\\boldsymbol{\\mathcal Y} - \\mathbf{\\bar x})^\\mathsf T}+\\mathbf Q\n",
     "\\hline \n",
     "& \\boldsymbol{\\mathcal Z} =  h(\\boldsymbol{\\mathcal{Y}}) \\\\\n",
     "& \\boldsymbol\\mu_z = \\sum w^m\\boldsymbol{\\mathcal{Z}} \\\\\n",


### PR DESCRIPTION
This is really minor issue.

`State` and `mean` in this context are synonyms, so technically is nothing wrong with using mean, but in my opinion using the same terms as at previous para will be better.