### PR TITLE
Typo fix for notebook 6.

### DIFF
--- a/06-Multivariate-Kalman-Filters.ipynb
+++ b/06-Multivariate-Kalman-Filters.ipynb
@@ -1584,7 +1584,7 @@
     "\n",
     "As a reminder, the linear equation $\\mathbf{Ax} = \\mathbf B$ represents a system of equations, where $\\mathbf{A}$ holds the coefficients of the state $\\mathbf x$. Performing the multiplication $\\mathbf{Ax}$ computes the right hand side values for that set of equations.\n",
     "\n",
-    "If $\\mathbf F$ contains the state transition for a given time step, then the product $\\mathbf{Fx}$ computes the state after that transition. Easy! Likewise, $\\mathbf B$ is the control function, $\\mathbf u$ is the control input, so $\\mathbf{Bu}$ computes the contribution of the controls to the state after the transition. Thus, the prior$\\mathbf{\\bar x}$ is computed as the sum of $\\mathbf{Fx}$ and $\\mathbf{Bu}$.\n",
+    "If $\\mathbf F$ contains the state transition for a given time step, then the product $\\mathbf{Fx}$ computes the state after that transition. Easy! Likewise, $\\mathbf B$ is the control function, $\\mathbf u$ is the control input, so $\\mathbf{Bu}$ computes the contribution of the controls to the state after the transition. Thus, the prior $\\mathbf{\\bar x}$ is computed as the sum of $\\mathbf{Fx}$ and $\\mathbf{Bu}$.\n",
     "\n",
     "The equivalent univariate equation is\n",
     "\n",
@@ -2986,7 +2986,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -3000,7 +3000,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added a missing space in Prediction Equations \ Mean section for notebook 6.

Thanks.
