### PR TITLE
Chapter 7 Fix LTI system theory equation for phi(t)

### DIFF
--- a/07-Kalman-Filter-Math.ipynb
+++ b/07-Kalman-Filter-Math.ipynb
@@ -718,7 +718,7 @@
     "\n",
     "[*Linear Time Invariant Theory*](https://en.wikipedia.org/wiki/LTI_system_theory), also known as LTI System Theory, gives us a way to find $\\Phi$ using the inverse Laplace transform. You are either nodding your head now, or completely lost.  I will not be using the Laplace transform in this book. LTI system theory tells us that \n",
     "\n",
-    "$$ \\Phi(t) = \\mathcal{L}^{-1}[(s\\mathbf{I} - \\mathbf{F})^{-1}]$$\n",
+    "$$ \\Phi(t) = \\mathcal{L}^{-1}[(s\\mathbf{I} - \\mathbf{A})^{-1}]$$\n",
     "\n",
     "I have no intention of going into this other than to say that the Laplace transform $\\mathcal{L}$ converts a signal into a space $s$ that excludes time, but finding a solution to the equation above is non-trivial. If you are interested, the Wikipedia article on LTI system theory provides an introduction. I mention LTI because you will find some literature using it to design the Kalman filter matrices for difficult problems. "
    ]
@@ -1758,7 +1758,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
I've fixed the inverse Laplace transform equation to compute \phi(t) in the Linear Time Invariant Theory section of Chapter 7. Instead of the state transition matrix F, the equation should have the system dynamics matrix A. 
Ref: Eq  4.2.2-10,  Estimation with Applications To Tracking and Navigation, Bar-Shalom Y, et.al, 2001