### PR TITLE
Fixed the train_filter function definition to use variable prior

### DIFF
--- a/02-Discrete-Bayes.ipynb
+++ b/02-Discrete-Bayes.ipynb
@@ -5599,7 +5599,7 @@
     "    track = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])\n",
     "\n",
     "    prior = np.array([.9] + [0.01]*9)\n",
-    "    normalize(belief)\n",
+    "    normalize(prior)\n",
     "    \n",
     "    robot = Train(len(track), kernel, sensor_accuracy)\n",
     "    for i in range(iterations):\n",


### PR DESCRIPTION
Fixed the train_filter function definition to use variable prior rather than belief (which is not part of the function).

I think this is correct. If not, please let me know for my own education :)