### PR TITLE
Fixed Unit of process_model for First Kalman Filter in Chapter 4

### DIFF
--- a/04-One-Dimensional-Kalman-Filters.ipynb
+++ b/04-One-Dimensional-Kalman-Filters.ipynb
@@ -936,7 +936,7 @@
     "x = gaussian(0., 20.**2)  # dog's position, N(0, 20**2)\n",
     "velocity = 1\n",
     "dt = 1. # time step in seconds\n",
-    "process_model = gaussian(velocity*dt, process_var) \n",
+    "process_model = gaussian(velocity, process_var) \n",
     "  \n",
     "# simulate dog and get measurements\n",
     "dog = DogSimulation(\n",


### PR DESCRIPTION
Fixed process_model to have `m/s` as unit. 

Currently, process_model.mean has unit of `m` which is passed to DogSimulation object as velocity. Inside move method, velocity is multiplied with time step which makes unit as `m*s`.