### PR TITLE
Change 10.90 to 11.35

### DIFF
--- a/06-Multivariate-Kalman-Filters.ipynb
+++ b/06-Multivariate-Kalman-Filters.ipynb
@@ -831,7 +831,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can see that the center of the ellipse shifted by a small amount (from 10 to 10.90) because the position changed. The ellipse also elongated, showing the correlation between position and velocity. How does the filter compute new values for $\\mathbf{\\bar P}$, and what is it based on? Note that I set the process noise `Q` to zero each time, so it is not due to me adding noise. It's a little to early to discuss this, but recall that in every filter so far the predict step entailed a loss of information. The same is true here. I will give you the details once we have covered a bit more ground."
+    "You can see that the center of the ellipse shifted by a small amount (from 10 to 11.35) because the position changed. The ellipse also elongated, showing the correlation between position and velocity. How does the filter compute new values for $\\mathbf{\\bar P}$, and what is it based on? Note that I set the process noise `Q` to zero each time, so it is not due to me adding noise. It's a little to early to discuss this, but recall that in every filter so far the predict step entailed a loss of information. The same is true here. I will give you the details once we have covered a bit more ground."
    ]
   },
   {


### PR DESCRIPTION
If you search for `dt = 0.3` you will find that the actual `x` position will be 11.35 after *innovation* (I borrowed your word here) because it's `10 + 4.5*0.3`
I think you were mistaken that `dt = 0.2`.

I chose to change the value 10.90 in the text instead of changing `dt` to `0.2` because it would alter the output of the subsequent cells.