### PR TITLE
improve naming in ch 1 "predict_using_gain_guess" example

### DIFF
--- a/01-g-h-filter.ipynb
+++ b/01-g-h-filter.ipynb
@@ -583,18 +583,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "previous: 160.00, prediction: 161.00 estimate 159.80\n",
-      "previous: 159.80, prediction: 160.80 estimate 162.16\n",
-      "previous: 162.16, prediction: 163.16 estimate 162.02\n",
-      "previous: 162.02, prediction: 163.02 estimate 161.77\n",
-      "previous: 161.77, prediction: 162.77 estimate 162.50\n",
-      "previous: 162.50, prediction: 163.50 estimate 163.94\n",
-      "previous: 163.94, prediction: 164.94 estimate 166.80\n",
-      "previous: 166.80, prediction: 167.80 estimate 167.64\n",
-      "previous: 167.64, prediction: 168.64 estimate 167.75\n",
-      "previous: 167.75, prediction: 168.75 estimate 169.65\n",
-      "previous: 169.65, prediction: 170.65 estimate 170.87\n",
-      "previous: 170.87, prediction: 171.87 estimate 172.16\n"
+      "previous estimate: 160.00, prediction: 161.00, estimate 159.80\n",
+      "previous estimate: 159.80, prediction: 160.80, estimate 162.16\n",
+      "previous estimate: 162.16, prediction: 163.16, estimate 162.02\n",
+      "previous estimate: 162.02, prediction: 163.02, estimate 161.77\n",
+      "previous estimate: 161.77, prediction: 162.77, estimate 162.50\n",
+      "previous estimate: 162.50, prediction: 163.50, estimate 163.94\n",
+      "previous estimate: 163.94, prediction: 164.94, estimate 166.80\n",
+      "previous estimate: 166.80, prediction: 167.80, estimate 167.64\n",
+      "previous estimate: 167.64, prediction: 168.64, estimate 167.75\n",
+      "previous estimate: 167.75, prediction: 168.75, estimate 169.65\n",
+      "previous estimate: 169.65, prediction: 170.65, estimate 170.87\n",
+      "previous estimate: 170.87, prediction: 171.87, estimate 172.16\n"
      ]
     }
    ],
@@ -608,30 +608,30 @@
     "time_step = 1.0  # day\n",
     "scale_factor = 4.0/10\n",
     "\n",
-    "def predict_using_gain_guess(weight, gain_rate, do_print=False):     \n",
+    "def predict_using_gain_guess(estimate, gain_rate, do_print=False):     \n",
     "    # store the filtered results\n",
-    "    estimates, predictions = [weight], []\n",
+    "    estimates, predictions = [estimate], []\n",
     "\n",
     "    # most filter literature uses 'z' for measurements\n",
     "    for z in weights: \n",
     "        # predict new position\n",
-    "        prediction = weight + gain_rate * time_step\n",
+    "        prediction = estimate + gain_rate * time_step\n",
     "\n",
     "        # update filter \n",
-    "        weight = prediction + scale_factor * (z - prediction)\n",
+    "        estimate = prediction + scale_factor * (z - prediction)\n",
     "\n",
     "        # save\n",
-    "        estimates.append(weight)\n",
+    "        estimates.append(estimate)\n",
     "        predictions.append(prediction)\n",
     "        if do_print:\n",
-    "            gh.print_results(estimates, prediction, weight)\n",
+    "            gh.print_results(estimates, prediction, estimate)\n",
     "\n",
     "    return estimates, predictions\n",
     "\n",
-    "initial_guess = 160.\n",
+    "initial_estimate = 160.\n",
     "\n",
     "estimates, predictions = predict_using_gain_guess(\n",
-    "    weight=initial_guess, gain_rate=1, do_print=True)     "
+    "    estimate=initial_estimate, gain_rate=1, do_print=True)     "
    ]
   },
   {
@@ -690,7 +690,7 @@
     }
    ],
    "source": [
-    "e, p = predict_using_gain_guess(initial_guess, -1.)\n",
+    "e, p = predict_using_gain_guess(initial_estimate, -1.)\n",
     "gh.plot_gh_results(weights, e, p)"
    ]
   },

--- a/kf_book/gh_internal.py
+++ b/kf_book/gh_internal.py
@@ -191,7 +191,7 @@ def plot_gh_results(weights, estimates, predictions, time_step=0):
 
 
 def print_results(estimates, prediction, weight):
-    print('previous: {:.2f}, prediction: {:.2f} estimate {:.2f}'.format(
+    print('previous estimate: {:.2f}, prediction: {:.2f}, estimate {:.2f}'.format(
           estimates[-2], prediction, weight))
 
 


### PR DESCRIPTION
  "weight" --> "estimate"
  "initial_guess" --> "initial_estimate"
  print_results: rename label "previous" --> "previous estimate", add comma

Since measurements, estimates, and predictions are all weights in this example, I found it difficult to follow the code given a variable named simply "weight".  Likewise, "initial_guess" for the newcomer isn't obviously an estimate (vs. say a prediction).  Finally in the printed output, I wasn't sure what "previous" was (measurement, estimate, or prediction).

I believe this change helps the example's clarity significantly.  Thank you for considering.