### PR TITLE
Changing plot_g_h_results import line

### DIFF
--- a/01-g-h-filter.ipynb
+++ b/01-g-h-filter.ipynb
@@ -931,6 +931,7 @@
    },
    "outputs": [],
    "source": [
+    "from kf_book.gh_internal import plot_g_h_results\n",
     "def g_h_filter(data, x0, dx, g, h, dt):\n",
     "    pass #  your solution here\n",
     "\n",
@@ -966,7 +967,6 @@
     }
    ],
    "source": [
-    "from kf_book.gh_internal import plot_g_h_results\n",
     "import matplotlib.pylab as pylab\n",
     "\n",
     "def g_h_filter(data, x0, dx, g, h, dt=1.):\n",


### PR DESCRIPTION
In the Exercise: Write Generic Algorithm section the user gets an
error trying to run the cell after uncomment the call to the function
because the plot_g_h_results function is imported on the next cell
This fix makes the import in the previous cell, resolving the issue