### PR TITLE
Remove useless code in 12-Particle-Filters.ipynb

### DIFF
--- a/12-Particle-Filters.ipynb
+++ b/12-Particle-Filters.ipynb
@@ -677,7 +677,6 @@
    "source": [
     "def resample_from_index(particles, weights, indexes):\n",
     "    particles[:] = particles[indexes]\n",
-    "    weights[:] = weights[indexes]\n",
     "    weights.fill(1.0 / len(weights))"
    ]
   },


### PR DESCRIPTION
In `12-Particle-Filters.ipynb`, the whole matrix of weights are filled at `weights.fill(1.0 / weights)`, so there is no need to update weight at the previews line.