### PR TITLE
add pip requirement to conda env and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ If you have conda or miniconda installed, you can create environment by
 
 and use
 
-    source activate kf_bf
+    conda activate kf_bf
 
 and
 
-    source deactivate kf_bf
+    conda deactivate kf_bf
 
 to activate and deactivate the environment.
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: kf_bf
 dependencies:
 - python
+- pip
 - ipython
 - jupyter
 - matplotlib


### PR DESCRIPTION
tested with miniconda using conda version 4.6.12+

I got the following warning:

> Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.