### PR TITLE
incorrect sign in product of Gaussian derivation

### DIFF
--- a/03-Gaussians.ipynb
+++ b/03-Gaussians.ipynb
@@ -1976,7 +1976,7 @@
     "$$\\begin{aligned}\n",
     "p(x \\mid z) &\\propto \\exp \\Big[-\\frac{(z-x)^2}{2\\sigma_z^2}\\Big]\\exp \\Big[-\\frac{(x-\\bar\\mu)^2}{2\\bar\\sigma^2}\\Big]\\\\\n",
     "&\\propto \\exp \\Big[-\\frac{(z-x)^2}{2\\sigma_z^2}-\\frac{(x-\\bar\\mu)^2}{2\\bar\\sigma^2}\\Big] \\\\\n",
-    "&\\propto \\exp \\Big[-\\frac{1}{2\\sigma_z^2\\bar\\sigma^2}[\\bar\\sigma^2(z-x)^2-\\sigma_z^2(x-\\bar\\mu)^2]\\Big]\n",
+    "&\\propto \\exp \\Big[-\\frac{1}{2\\sigma_z^2\\bar\\sigma^2}[\\bar\\sigma^2(z-x)^2+\\sigma_z^2(x-\\bar\\mu)^2]\\Big]\n",
     "\\end{aligned}$$\n",
     "\n",
     "Now we multiply out the squared terms and group in terms of the posterior $x$.\n",


### PR DESCRIPTION
The factorization on the third line appears incorrect. Both terms should be positive after factoring out the negative sign.

![image](https://user-images.githubusercontent.com/23066079/64914836-44d0bf80-d71f-11e9-88ca-94c37cd12ad7.png)
