### PR TITLE
"typo" correction

### DIFF
--- a/11-Extended-Kalman-Filters.ipynb
+++ b/11-Extended-Kalman-Filters.ipynb
@@ -101,7 +101,7 @@
     "\n",
     "The EKF does not alter the Kalman filter's linear equations. Instead, it *linearizes* the nonlinear equations at the point of the current estimate, and uses this linearization in the linear Kalman filter. \n",
     "\n",
-    "*Linearize* means what it sounds like. We find a line that most closely matches the curve at a defined point. The graph below linearizes the parabola $f(x)=x^2−2x$ at $x=1.5$."
+    "*Linearize* means what it sounds like. We find a line that most closely matches the curve at a defined point. The graph below linearizes the parabola $f(x)=x^2-2x$ at $x=1.5$."
    ]
   },
   {


### PR DESCRIPTION
"unknown character" was displayed instead of the "-" in the "in text" equation: "f(x) = x^2-2x"

for some reason i cannot verify if my modification fixes the problem, (can't view the rendered file on my forked branch, i am getting an error when loading the file...), but i'm pretty sure it's ok. 