### PR TITLE
Fix interactive elements in 02-Discrete-Bayes.ipynb

### DIFF
--- a/02-Discrete-Bayes.ipynb
+++ b/02-Discrete-Bayes.ipynb
@@ -602,17 +602,17 @@
     "from ipywidgets import interact, IntSlider\n",
     "\n",
     "belief = np.array([.35, .1, .2, .3, 0, 0, 0, 0, 0, .05])\n",
-    "beliefs = []\n",
+    "perfect_beliefs = []\n",
     "\n",
     "for _ in range(20):\n",
     "    # Simon takes one step to the right\n",
     "    belief = perfect_predict(belief, 1)\n",
-    "    beliefs.append(belief)\n",
+    "    perfect_beliefs.append(belief)\n",
     "\n",
     "def simulate(time_step):\n",
-    "    book_plots.bar_plot(beliefs[time_step], ylim=(0, .4))\n",
+    "    book_plots.bar_plot(perfect_beliefs[time_step], ylim=(0, .4))\n",
     "    \n",
-    "interact(simulate, time_step=IntSlider(value=0, max=len(beliefs)-1));"
+    "interact(simulate, time_step=IntSlider(value=0, max=len(perfect_beliefs)-1));"
    ]
   },
   {
@@ -778,20 +778,20 @@
    ],
    "source": [
     "belief = np.array([1.0, 0, 0, 0, 0, 0, 0, 0, 0, 0])\n",
-    "beliefs = []\n",
+    "predict_beliefs = []\n",
     "    \n",
     "for i in range(100):\n",
     "    belief = predict_move(belief, 1, .1, .8, .1)\n",
-    "    beliefs.append(belief)\n",
+    "    predict_beliefs.append(belief)\n",
     "\n",
     "print('Final Belief:', belief)\n",
     "\n",
     "# make interactive plot\n",
     "def show_prior(step):\n",
-    "    book_plots.bar_plot(beliefs[step-1])\n",
+    "    book_plots.bar_plot(predict_beliefs[step-1])\n",
     "    plt.title('Step {}'.format(step))\n",
     "\n",
-    "interact(show_prior, step=IntSlider(value=1, max=len(beliefs)));"
+    "interact(show_prior, step=IntSlider(value=1, max=len(predict_beliefs)));"
    ]
   },
   {

--- a/02-Discrete-Bayes.ipynb
+++ b/02-Discrete-Bayes.ipynb
@@ -1220,25 +1220,28 @@
     "    return priors, posteriors\n",
     "\n",
     "\n",
-    "def plot_posterior(posteriors, i):\n",
+    "def plot_posterior(hallway, posteriors, i):\n",
     "    plt.title('Posterior')\n",
     "    book_plots.bar_plot(hallway, c='k')\n",
     "    book_plots.bar_plot(posteriors[i], ylim=(0, 1.0))\n",
     "    plt.axvline(i % len(hallway), lw=5)    \n",
     "    \n",
-    "def plot_prior(priors, i):\n",
+    "def plot_prior(hallway, priors, i):\n",
     "    plt.title('Prior')\n",
     "    book_plots.bar_plot(hallway, c='k')\n",
     "    book_plots.bar_plot(priors[i], ylim=(0, 1.0), c='#ff8015')\n",
     "    plt.axvline(i % len(hallway), lw=5)    \n",
     "\n",
-    "def animate_discrete_bayes(step):\n",
-    "    step -= 1\n",
-    "    i = step // 2    \n",
-    "    if step % 2 == 0:\n",
-    "        plot_prior(priors, i)\n",
-    "    else:\n",
-    "        plot_posterior(posteriors, i)"
+    "def animate_discrete_bayes(hallway, priors, posteriors):\n",
+    "    def animate(step):\n",
+    "        step -= 1\n",
+    "        i = step // 2    \n",
+    "        if step % 2 == 0:\n",
+    "            plot_prior(hallway, priors, i)\n",
+    "        else:\n",
+    "            plot_posterior(hallway, posteriors, i)\n",
+    "    \n",
+    "    return animate"
    ]
   },
   {
@@ -1278,7 +1281,7 @@
     "zs = [hallway[i % len(hallway)] for i in range(50)]\n",
     "\n",
     "priors, posteriors = discrete_bayes_sim(prior, kernel, zs, z_prob, hallway)\n",
-    "interact(animate_discrete_bayes, step=IntSlider(value=1, max=len(zs)*2));"
+    "interact(animate_discrete_bayes(hallway, priors, posteriors), step=IntSlider(value=1, max=len(zs)*2));"
    ]
   },
   {
@@ -1328,7 +1331,7 @@
     "zs = [1, 0, 1, 0, 0, 1]\n",
     "z_prob = 0.75\n",
     "priors, posteriors = discrete_bayes_sim(prior, kernel, zs, z_prob, hallway)\n",
-    "interact(animate_discrete_bayes, step=IntSlider(value=12, max=len(zs)*2));"
+    "interact(animate_discrete_bayes(hallway, priors, posteriors), step=IntSlider(value=12, max=len(zs)*2));"
    ]
   },
   {
@@ -1359,7 +1362,7 @@
    "source": [
     "measurements = [1, 0, 1, 0, 0, 1, 1]\n",
     "priors, posteriors = discrete_bayes_sim(prior, kernel, measurements, z_prob, hallway);\n",
-    "plot_posterior(posteriors, 6)"
+    "plot_posterior(hallway, posteriors, 6)"
    ]
   },
   {


### PR DESCRIPTION
When running all code in chapter 2 (02-Discrete-Bayes.ipynb), then interacting with first slider (dog moving with perfect prediction) shows result of second interactive element (dog moving inperfect prediction). Also some other sliders show results for another slider. This PR fixes these errors by renaming variables to not conflict and upgrading step functions to utilize scopes.