### PR TITLE
Replace source command with conda command

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ If you have conda or miniconda installed, you can create environment by
 
 and use
 
-    source activate kf_bf
+    conda activate kf_bf
 
 and
 
-    source deactivate kf_bf
+    conda deactivate kf_bf
 
 to activate and deactivate the environment.
 


### PR DESCRIPTION
`source` works for activation, but not for deactivation. `conda` works for both operations. This is also in line with the instructions from Anaconda.

![Screenshot from 2020-04-25 13-29-19](https://user-images.githubusercontent.com/1830620/80278762-2db47000-86f9-11ea-8b55-6453bd4e8efb.png)
