### PR TITLE
fix typo in documenting book_plots plot_errorbars

### DIFF
--- a/kf_book/book_plots.py
+++ b/kf_book/book_plots.py
@@ -80,7 +80,7 @@ def plot_errorbars(bars, xlims, ylims=(-1, 1)):
         tuple containing min and max values for x axis
 
     y-lims : tuple, optional
-        tuple containing min and max values for x axis
+        tuple containing min and max values for y axis ( the default is (-1, 1))
 
     Example
     -------


### PR DESCRIPTION
Changed documentation description for `y-lims` parameter to `... values for y axis`