### PR TITLE
docs: Fix a few typos

### DIFF
--- a/experiments/ILS.py
+++ b/experiments/ILS.py
@@ -35,7 +35,7 @@ def transmitter_range(pos, transmitter_pos):
 
 
 
-# compute measurement of where you are with respect to seach sensor
+# compute measurement of where you are with respect to search sensor
 
 
 rz= transmitter_range(user_pos, t_pos) # $B21,22

--- a/experiments/gauss.py
+++ b/experiments/gauss.py
@@ -48,7 +48,7 @@ class gaussian(object):
         return (self.mean, self.variance)
 
     def __getitem__ (self,index):
-        """ maybe silly, allows you to access obect as a tuple:
+        """ maybe silly, allows you to access object as a tuple:
         a = gaussian(3,4)
         print (tuple(a))
         """

--- a/experiments/ukf_range.py
+++ b/experiments/ukf_range.py
@@ -36,7 +36,7 @@ class RadarSim(object):
         self.alt = self.alt + .1*randn()
         self.pos = self.pos + self.vel*self.dt
 
-        # add measurment noise
+        # add measurement noise
         err = self.pos * 0.05*randn()
         slant_dist = math.sqrt(self.pos**2 + self.alt**2)
 

--- a/kf_book/book_plots.py
+++ b/kf_book/book_plots.py
@@ -334,7 +334,7 @@ def IntSlider(value, **kwargs):
 
 def plot_measurements(xs, ys=None, dt=None, color='k', lw=1, label='Measurements',
                       lines=False, **kwargs):
-    """ Helper function to give a consistant way to display
+    """ Helper function to give a consistent way to display
     measurements in the book.
     """
     if ys is None and dt is not None:
@@ -357,7 +357,7 @@ def plot_measurements(xs, ys=None, dt=None, color='k', lw=1, label='Measurements
 
 
 def plot_residual_limits(Ps, stds=1.):
-    """ plots standand deviation given in Ps as a yellow shaded region. One std
+    """ plots standard deviation given in Ps as a yellow shaded region. One std
     by default, use stds for a different choice (e.g. stds=3 for 3 standard
     deviations.
     """


### PR DESCRIPTION
There are small typos in:
- experiments/ILS.py
- experiments/gauss.py
- experiments/ukf_range.py
- kf_book/book_plots.py

Fixes:
- Should read `standard` rather than `standand`.
- Should read `search` rather than `seach`.
- Should read `object` rather than `obect`.
- Should read `measurement` rather than `measurment`.
- Should read `consistent` rather than `consistant`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md