### PR TITLE
Fix a typo

### DIFF
--- a/06-Multivariate-Kalman-Filters.ipynb
+++ b/06-Multivariate-Kalman-Filters.ipynb
@@ -1511,7 +1511,7 @@
     "    xs, cov = np.array(xs), np.array(cov)\n",
     "```\n",
     "\n",
-    "There's an easy way to avoid this. `filtery.common` provides the `Saver` class which will save all attributes in the Kalman filter class each time `Saver.save()` is called. Let's see it in action and then we will talk about it more."
+    "There's an easy way to avoid this. `filterpy.common` provides the `Saver` class which will save all attributes in the Kalman filter class each time `Saver.save()` is called. Let's see it in action and then we will talk about it more."
    ]
   },
   {


### PR DESCRIPTION
Small typo in markdown cell of `06-Multivariate-Kalman-Filters.ipynb`.

- Changed `filtery.common` to `filterpy.common`.