### PR TITLE
Remove redundant "dx += accel"

### DIFF
--- a/01-g-h-filter.ipynb
+++ b/01-g-h-filter.ipynb
@@ -1266,7 +1266,6 @@
     "    zs = []\n",
     "    for i in range(count):\n",
     "        zs.append(x0 + accel * (i**2) / 2 + dx*i + randn()*noise_factor)\n",
-    "        dx += accel\n",
     "    return zs\n",
     "   \n",
     "predictions = []\n",
@@ -2073,7 +2072,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.4"
   },
   "nbdime-conflicts": {
    "local_diff": [


### PR DESCRIPTION
In Chapter 1, under "Exercise: The Effect of Acceleration", the solution uses the closed-form solution to the differential equations for acceleration, velocity, and displacement. 

```
def gen_data(x0, dx, count, noise_factor, accel=0.):
    zs = []
    for i in range(count):
        zs.append(x0 + accel * (i**2) / 2 + dx*i + randn()*noise_factor)
        dx += accel
    return zs
```

However, because this solution was used, there is no need to increment `dx`; in this solution, `dx` should just remain as its initial value (which we could call `dx0`, but I did not change it here).

See #381, #369, and #301. This problem appears to have arisen from the commit associated with #301, where the equation was changed from an iterative method to the closed-form solution, but the `dx += accel` was not removed.

This does not at all impact the lesson being taught in this section, but it might be confusing for readers if they cannot replicate the solution, especially since the solution uses zero noise.