### PR TITLE
Fix a minor typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ GitHub is able to render the notebooks directly. The quickest way to view a note
 PDF Version
 -----
 
-A PDF version of the book is available [here]https://drive.google.com/file/d/0By_SW19c1BfhSVFzNHc0SjduNzg/view?usp=sharing&resourcekey=0-41olC9ht9xE3wQe2zHZ45A)
+A PDF version of the book is available [here](https://drive.google.com/file/d/0By_SW19c1BfhSVFzNHc0SjduNzg/view?usp=sharing&resourcekey=0-41olC9ht9xE3wQe2zHZ45A)
 
 
 The PDF will usually lag behind what is in github as I don't update it for every minor check in.


### PR DESCRIPTION
I would like to inform a very minor typo, (missing `(`) for this great and helpful book.

I hope that this book will be more complete by fixing the very minor mistake.