### PR TITLE
fix a hyperlink in g_h filter notebook

### DIFF
--- a/01-g-h-filter.ipynb
+++ b/01-g-h-filter.ipynb
@@ -816,7 +816,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let me introduce some more formal terminology. The *system* is the object that we want to estimate. In this chapter the system is whatever we are trying to weigh. Some texts call this the *plant*. That terminology comes from control system theory. https://en.wikipedia.org/wiki/Plant_(control_theory)\n",
+    "Let me introduce some more formal terminology. The *system* is the object that we want to estimate. In this chapter the system is whatever we are trying to weigh. Some texts call this the [*plant*](https://en.wikipedia.org/wiki/Plant_(control_theory)). That terminology comes from control system theory. \n",
     "\n",
     "The *state* of the system is the current configuration or values of that system that is of interest to us. We are interested only in the weight reading. If I put a 100 kg weight on the scale, the state is 100kg. We define the state based on what is relevant to us. The color of the scale is irrelevant to us so we do not include those values in the state. A QA engineer for the manufacturer might include color in the state so that she can track and control the manufacturing process. \n",
     "\n",
@@ -2073,7 +2073,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   },
   "nbdime-conflicts": {
    "local_diff": [


### PR DESCRIPTION
This change resolves #439 by adding a parenthesis to a link in the g-h filter notebook and setting it as a hyperlink.