### PR TITLE
matplotlib deprecation: replace grid(b=False) with grid(False) to fix b parameter deprecation in matplotlib grid call

### DIFF
--- a/05-Multivariate-Gaussians.ipynb
+++ b/05-Multivariate-Gaussians.ipynb
@@ -776,7 +776,7 @@
     "plot_covariance_ellipse((2, 7), P, fc='g', alpha=0.2, \n",
     "                        std=[1, 2, 3],\n",
     "                        title='|2 0|\\n|0 6|')\n",
-    "plt.gca().grid(b=False);"
+    "plt.gca().grid(False);"
    ]
   },
   {
@@ -842,7 +842,7 @@
     "P = [[2, 0], [0, 2]]\n",
     "plot_covariance_ellipse(x, P, fc='g', alpha=0.2, \n",
     "                       title='|2 0|\\n|0 2|')\n",
-    "plt.gca().grid(b=False)"
+    "plt.gca().grid(False)"
    ]
   },
   {
@@ -885,7 +885,7 @@
     "P = [[2, 0], [0, 6]]\n",
     "plot_covariance_ellipse(x, P, fc='g', alpha=0.2, \n",
     "                    title='|2 0|\\n|0 6|')\n",
-    "plt.gca().grid(b=False)"
+    "plt.gca().grid(False)"
    ]
   },
   {

--- a/kf_book/mkf_internal.py
+++ b/kf_book/mkf_internal.py
@@ -373,7 +373,7 @@ def plot_3d_sampled_covariance(mean, cov):
 def plot_3_covariances():
     P = [[2, 0], [0, 2]]
     plt.subplot(131)
-    plt.gca().grid(b=False)
+    plt.gca().grid(False)
     plt.gca().set_xticks([0, 1, 2, 3, 4])
     plot_covariance_ellipse((2, 7), cov=P, facecolor='g', alpha=0.2,
                             title='|2 0|\n|0 2|', std=[3], axis_equal=False)
@@ -381,7 +381,7 @@ def plot_3_covariances():
     plt.gca().set_aspect('equal', adjustable='box')
 
     plt.subplot(132)
-    plt.gca().grid(b=False)
+    plt.gca().grid(False)
     plt.gca().set_xticks([0, 1, 2, 3, 4])
     P = [[2, 0], [0, 6]]
     plt.ylim((0, 15))
@@ -390,7 +390,7 @@ def plot_3_covariances():
                             std=[3], axis_equal=False, title='|2 0|\n|0 6|')
 
     plt.subplot(133)
-    plt.gca().grid(b=False)
+    plt.gca().grid(False)
     plt.gca().set_xticks([0, 1, 2, 3, 4])
     P = [[2, 1.2], [1.2, 2]]
     plt.ylim((0, 15))

--- a/kf_book/nonlinear_plots.py
+++ b/kf_book/nonlinear_plots.py
@@ -234,7 +234,7 @@ def plot_monte_carlo_mean(xs, ys, f, mean_fx, label, plot_colormap=True):
     computed_mean_y = np.average(fys)
 
     ax = plt.subplot(121)
-    ax.grid(b=False)
+    ax.grid(False)
 
     plot_bivariate_colormap(xs, ys)
 
@@ -243,7 +243,7 @@ def plot_monte_carlo_mean(xs, ys, f, mean_fx, label, plot_colormap=True):
     ax.set_ylim(-20, 20)
 
     ax = plt.subplot(122)
-    ax.grid(b=False)
+    ax.grid(False)
 
     plt.scatter(fxs, fys, marker='.', alpha=0.02, color='k')
     plt.scatter(mean_fx[0], mean_fx[1],
@@ -268,7 +268,7 @@ def plot_cov_ellipse_colormap(cov=[[1,1],[1,1]]):
     pos[:, :, 1] = Y
     plt.axes(xticks=[], yticks=[], frameon=True)
     rv = scipy.stats.multivariate_normal((0,0), cov)
-    plt.gca().grid(b=False)
+    plt.gca().grid(False)
     plt.gca().imshow(rv.pdf(pos), cmap=plt.cm.Greys, origin='lower')
     plt.show()
 

--- a/kf_book/pf_internal.py
+++ b/kf_book/pf_internal.py
@@ -143,14 +143,14 @@ def plot_monte_carlo_ukf():
     fxs, fys = f(xs, ys)
 
     plt.subplot(121)
-    plt.gca().grid(b=False)
+    plt.gca().grid(False)
 
     plt.scatter(xs, ys, marker='.', alpha=.2, color='k')
     plt.xlim(-25, 25)
     plt.ylim(-25, 25)
 
     plt.subplot(122)
-    plt.gca().grid(b=False)
+    plt.gca().grid(False)
 
     plt.scatter(fxs, fys, marker='.', alpha=0.2, color='k')
 


### PR DESCRIPTION
the `b` parameter in matplotlib `grid(...)` function is deprecated since matplotlib 3.7 (see [matplotlib 25267](https://github.com/matplotlib/matplotlib/issues/25267)). This is easily fixed by supplying this argument as a positional argument.