### PR TITLE
Fix missing variable in call (01-g/h filters)

### DIFF
--- a/01-g-h-filter.ipynb
+++ b/01-g-h-filter.ipynb
@@ -1202,7 +1202,7 @@
    ],
    "source": [
     "zs = gen_data(x0=5., dx=2., count=100, noise_factor=100)\n",
-    "data = g_h_filter(data=zs, x0=5., dx=2., g=0.2, h=0.02)\n",
+    "data = g_h_filter(data=zs, x0=5., dx=2., dt=1., g=0.2, h=0.02)\n",
     "plot_g_h_results(measurements=zs, filtered_data=data)"
    ]
   },


### PR DESCRIPTION
Missing the `dt` parameter in the call to the filter