### PR TITLE
Fix direct dependency versions (aka "making this book live a little longer")

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-filterpy
-jupyter
-notebook
-sympy
-numpy
-scipy
-matplotlib
+filterpy==1.4.5
+jupyter==1.1.1
+notebook==7.2.2
+sympy==1.13.2
+numpy==1.26.4
+scipy==1.14.1
+matplotlib==3.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Chapter notebooks briefly tested on Python 3.11.9 and the versions below
 filterpy==1.4.5
 jupyter==1.1.1
 notebook==7.2.2


### PR DESCRIPTION
First of all: Thank you for the effort you put into this book. I'm currently reading and enjoying it.

(I have read your contributing guidelines, so I'll make this quick and the diff small. Feel free to just ignore this PR.)

Some notebook cells do not work under `numpy > 2.0.0` and `matplotlib > 3.7.0`.
I have fixed the direct dependencies to versions that I have now checked are working on Python 3.11.9 and the notebooks on `master`. This way we could get some more years of life out of this awesome book. 

I know that most people reading the book should be able to fix the issues themselves, but keeping everyone from having to painstakingly go through many versions of dependencies might be worth the effort here.

